### PR TITLE
reimplement action filters using hooks

### DIFF
--- a/lib/active_admin/application.rb
+++ b/lib/active_admin/application.rb
@@ -150,8 +150,8 @@ module ActiveAdmin
     AbstractController::Callbacks::ClassMethods.public_instance_methods.
       select { |m| m.match(/_action\z/) }.each do |name|
       define_method name do |*args, &block|
-        controllers_for_filters.each do |controller|
-          controller.public_send name, *args, &block
+        ActiveSupport.on_load(:active_admin_controller) do
+          public_send name, *args, &block
         end
       end
     end

--- a/lib/active_admin/base_controller.rb
+++ b/lib/active_admin/base_controller.rb
@@ -77,5 +77,7 @@ module ActiveAdmin
       { controller: controller, action: action }
     end
 
+    ActiveSupport.run_load_hooks(:active_admin_controller_base, self)
+    ActiveSupport.run_load_hooks(:active_admin_controller, self)
   end
 end

--- a/lib/active_admin/devise.rb
+++ b/lib/active_admin/devise.rb
@@ -30,6 +30,9 @@ module ActiveAdmin
       included do
         layout "active_admin_logged_out"
         helper ::ActiveAdmin::ViewHelpers
+
+        ActiveSupport.run_load_hooks(:active_admin_controller_devise, self)
+        ActiveSupport.run_load_hooks(:active_admin_controller, self)
       end
 
       # Redirect to the default namespace on logout


### PR DESCRIPTION
Defining Action filters (`before_action`, `skip_before_action`, etc) using `ActiveAdmin.before_action` on the initializer file produces the following error.

```
lib/active_admin/base_controller/authorization.rb:3:in `<module:ActiveAdmin>': uninitialized constant InheritedResources::Base (NameError)
Did you mean?  Base64
```

ActiveAdmin module forwards the filter call to all controllers. That means that we are using classes meant to be autoloaded inside the initializer. That's not allowed in Rails 7.x (see the second red box of
https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#config-autoload-paths).

This PR defers the forward until controllers are loaded by using `ActiveSupport.on_load hook`.

# What's missing?
- Write some feature specs
- Remove unused `ActiveAdmin::Aplication.controllers_for_filters` and `ActiveAdmin::Devise.controllers_for_filters`
