### PR TITLE
Support specs running with config.eager_load=true

### DIFF
--- a/lib/active_admin/engine.rb
+++ b/lib/active_admin/engine.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 module ActiveAdmin
   class Engine < ::Rails::Engine
-    initializer "active_admin.load_app_path" do |app|
+    # Set default values for app_path and load_paths before running initializers
+    initializer "active_admin.load_app_path", before: :load_config_initializers do |app|
       ActiveAdmin::Application.setting :app_path, app.root
       ActiveAdmin::Application.setting :load_paths, [File.expand_path("app/admin", app.root)]
     end

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -54,11 +54,6 @@ copy_file File.expand_path("templates/models/tagging.rb", __dir__), "app/models/
 
 copy_file File.expand_path("templates/helpers/time_helper.rb", __dir__), "app/helpers/time_helper.rb"
 
-# Rails 7: do not eager load classes to prevent Zeitwerk errors in test_app
-gsub_file "config/environments/test.rb", /  config.eager_load = ENV\["CI"\].present\?/, <<-RUBY
-  config.eager_load = false
-RUBY
-
 gsub_file "config/environments/test.rb", /  config.cache_classes = true/, <<-RUBY
 
   config.cache_classes = !ENV['CLASS_RELOADING']


### PR DESCRIPTION
`ActiveAdmin::Aplication.remove_active_admin_load_paths_from_rails_autoload_and_eager_load` is not working on feature tests.
Starting from Rails 7.0, running tests with eager_load enabled produces the following error:
```
Failure/Error: require
"#{ActiveAdmin::TestApplication.new.full_app_dir}/config/environment.rb"

FrozenError:
  can't modify frozen Array: ["<root>/tmp/test_apps/rails_70/app/admin",
"<root>/tmp/test_apps/rails_70/app/channels",
"<root>/tmp/test_apps/rails_70/app/controllers",
"<root>/tmp/test_apps/rails_70/app/controllers/concerns",
"<root>/tmp/test_apps/rails_70/app/helpers",
"<root>/tmp/test_apps/rails_70/app/jobs",
"<root>/tmp/test_apps/rails_70/app/mailers",
"<root>/tmp/test_apps/rails_70/app/models",
"<root>/tmp/test_apps/rails_70/app/models/concerns",
"<root>/tmp/test_apps/rails_70/app/policies",
"<rvm>/ruby-2.7.5/gems/inherited_resources-1.13.1/app/controllers",
"<rvm>/ruby-2.7.5/gems/devise-4.8.1/app/controllers",
"<rvm>/ruby-2.7.5/gems/devise-4.8.1/app/helpers",
"<rvm>/ruby-2.7.5/gems/devise-4.8.1/app/mailers",
"<rvm>/ruby-2.7.5/gems/actionmailbox-7.0.2.2/app/controllers",
"<rvm>/ruby-2.7.5/gems/actionmailbox-7.0.2.2/app/jobs",
"<rvm>/ruby-2.7.5/gems/actionmailbox-7.0.2.2/app/models",
"<rvm>/ruby-2.7.5/gems/activestorage-7.0.2.2/app/controllers",
"<rvm>/ruby-2.7.5/gems/activestorage-7.0.2.2/app/controllers/concerns",
"<rvm>/ruby-2.7.5/gems/activestorage-7.0.2.2/app/jobs",
"<rvm>/ruby-2.7.5/gems/activestorage-7.0.2.2/app/models"]
````

`ActiveAdmin::Aplication.remove_active_admin_load_paths_from_rails_autoload_and_eager_load` fails because `ActiveAdmin.application.load_paths` value is `<root>/app/admin` when it should be `<root>/tmp/test_apps/rails_70/app/admin`.
`ActiveAdmin::ApplicationSettings` initialize `load_path` with `[File.expand_path("app/admin", Rails.root)]`.
On testing app bootstrap ([this line](https://github.com/activeadmin/activeadmin/blob/master/features/support/env.rb#L12)) `Rails.root` is nil and `File.expand_path` is expanding to the folder where `rake test` runs (`<root>`).

`ActiveAdmin::Engine` has an initializer to define default value for `load_paths`. The problem is that the block runs after initializers in `config/initializers` folder, including `ActiveAdmin.setup` where `ActiveAdmin::Aplication.remove_active_admin_load_paths_from_rails_autoload_and_eager_load` is called from.

This commit makes sure the block runs before `config/initializers`. That way the block sets a proper default.
